### PR TITLE
Update tactvisor.ini 'BLUETOOTH_NAME' to "TactVisor_"

### DIFF
--- a/variants/bhaptics/tactvisor/tactvisor.ini
+++ b/variants/bhaptics/tactvisor/tactvisor.ini
@@ -4,7 +4,7 @@ extends = base:bhaptics
 build_flags =
     ${base:bhaptics.build_flags}
     -D BH_BLE_APPEARANCE=508
-    '-D BLUETOOTH_NAME="Tactal_"'
+    '-D BLUETOOTH_NAME="TactVisor_"'
     '-D BH_SERIAL_NUMBER={ 0xed, 0xcb, 0x55, 0x7c, 0xd7, 0xb9, 0x16, 0xc5, 0x18, 0x2a }'
 
 build_src_filter =


### PR DESCRIPTION
Was previously set to "Tactal_", bHaptics now correctly identifies it as a TactVisor.